### PR TITLE
[CHORE] 헬스체크 추가 및 스크립트 수정

### DIFF
--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -10,23 +10,39 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DATABASE}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT}:${POSTGRES_PORT}"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - devine-network
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DATABASE}" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
   redis:
     image: redis:7.2-alpine
     container_name: devine-redis
     restart: unless-stopped
-    command: ["redis-server", "--appendonly", "yes"]
+    command: >
+      redis-server
+      --appendonly yes
+      --requirepass ${REDIS_PASSWORD}
+      --maxmemory-policy allkeys-lru
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT}:${REDIS_PORT}"
     volumes:
       - redis_data:/data
     networks:
       - devine-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
 networks:
   devine-network:

--- a/service/docker-compose.yml
+++ b/service/docker-compose.yml
@@ -6,50 +6,44 @@ services:
     container_name: devine-backend
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "${SPRING_PORT}:${SPRING_PORT}"
     env_file:
       - .env
     environment:
       - TZ=Asia/Seoul
-      - JAVA_OPTS=-Xmx512m -Xms256m
+      - JAVA_OPTS=-Xmx512m -Xms256m -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:${SPRING_PORT}/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 90s
     networks:
       - devine-network
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
+    volumes:
+      - ./logs/backend:/app/logs
 
   ai:
     image: ${DOCKER_USERNAME}/devine-ai:${DOCKER_IMAGE_TAG:-latest}
     container_name: devine-ai
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      - "${FAST_PORT}:${FAST_PORT}"
     env_file:
       - .env
     environment:
       - PYTHONUNBUFFERED=1
       - TZ=Asia/Seoul
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:${FAST_PORT}/health"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      start_period: 60s
     networks:
       - devine-network
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
+    volumes:
+      - ./logs/ai:/app/logs
 
 networks:
   devine-network:


### PR DESCRIPTION
1. db : private ec2
- db 포트 변수화
- redis, postgresql 헬스 체크 추가
- redis command : AOF 활성화, pw 옵션 추가, 메모리 삭제 옵션

2 service : public ec2
- 서비스 포트 변수화
- 헬스 체크 시작 60->90 : 스프링 콜드 스타트 고려
- spring JVM 옵션 추가
- 컨테이너 로그를 호스트 볼륨에 마운트
  - AI 서버 로그 사이즈로 인해 파일 크기별 로그 관리 -> 날짜별 로그 관리로 수정 필요하여, 도커에서 로그 관리 관련 옵션을 제거하고 호스트에 저장하도록 함
  - 스프링 logback, fast logging TimedRotatingFileHandler 을 통해 날짜별 로그 파일 관리 추가 예정