### PR TITLE
[REFACTOR] redis -> valkey 변경

### DIFF
--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -22,23 +22,23 @@ services:
       retries: 3
       start_period: 10s
 
-  redis:
-    image: redis:7.2-alpine
-    container_name: devine-redis
+  valkey:
+    image: valkey/valkey:9.0-alpine
+    container_name: devine-valkey
     restart: unless-stopped
     command: >
-      redis-server
+      valkey-server
       --appendonly yes
       --requirepass ${REDIS_PASSWORD}
       --maxmemory-policy allkeys-lru
     ports:
       - "${REDIS_PORT}:${REDIS_PORT}"
     volumes:
-      - redis_data:/data
+      - valkey_data:/data
     networks:
       - devine-network
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      test: ["CMD", "valkey-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -50,4 +50,4 @@ networks:
 
 volumes:
   postgres_data:
-  redis_data:
+  valkey_data:


### PR DESCRIPTION
- Issue #5
- 연관 프로젝트 Issue https://github.com/DeVine-2025/DeVine_BackEnd/issues/22

# db/docker-compose.yml : redis 에서 valkey 로 변경

1. valkey 버전 : 9.0
https://valkey.io/topics/releases/
공식 문서 릴리즈 테이블에서 ‘stable release’ 의 최신 버전으로 사용

2. Valkey 전환 이유
- **라이선스 안정성 및 오픈 소스 지속성**: Redis는 7.4 버전부터 라이선스 정책을 변경하여 더 이상 완전한 오픈 소스(OSI 인증)가 아닌 반면 Valkey는 Linux Foundation 산하의 프로젝트로, 라이선스 제약 없이 영구적으로 자유롭게 사용할 수 있음
- **완벽한 하위 호환성**: Valkey는 Redis 7.2를 기반으로 포크된 프로젝트이므로, 현재 `DeVine_BackEnd`에서 사용 중인 Lettuce 라이브러리 및 `RedisTemplate` 설정과 완벽하게 호환 가능 (`spring-boot-starter-data-redis` 의존성 유지)
- **성능 최적화**: Valkey는 다중 스레드 성능 향상 등 Redis 7.2 대비 최신 하드웨어 자원을 더 효율적으로 사용하도록 개선되고 있습니다. 특히 AI 서버(`devine_ai`)와 연동되어 데이터 처리가 빈번해질 경우 이점이 있음

3. private ec2 적용(로컬에서도 동일하게 실행!)
```
# 1. 기존 도커 제거
cd ~/devine-deply/db
docker compose down -v # 볼륨까지 전체 삭제

# 2. valkey 로 변경한 deploy 받기
git pull origin main
docker compose up -d
```

4. 동작 확인
<img width="1240" height="258" alt="image" src="https://github.com/user-attachments/assets/7359b84e-8fe4-4896-a343-c46a0b6fce36" />

