### PR TITLE
[FEATURE] nginx SSE 설정 추가

### DIFF
--- a/service/nginx/conf.d/api.devine.kr.conf
+++ b/service/nginx/conf.d/api.devine.kr.conf
@@ -16,6 +16,24 @@ server {
     ssl_certificate /etc/nginx/ssl/live/api.devine.kr/fullchain.pem;
     ssl_certificate_key /etc/nginx/ssl/live/api.devine.kr/privkey.pem;
 
+    # SSE (Server-Sent Events)
+    location /sse/ {
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding off;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
     # Backend API
     location / {
         proxy_pass http://backend;


### PR DESCRIPTION
1. /SSE 로 시작되는 프리픽스에만 적용되도록 설정
```
  설정: proxy_http_version 1.1                                                 
  역할: HTTP/1.1 사용으로 keep-alive 및 chunked transfer 지원                  
  ────────────────────────────────────────                  
  설정: proxy_set_header Connection ''                                         
  역할: Connection 헤더를 비워서 keep-alive 유지 (close 방지)
  ────────────────────────────────────────
  설정: proxy_buffering off
  역할: 핵심 - nginx가 응답을 버퍼링하지 않고 즉시 클라이언트에 전달
  ────────────────────────────────────────
  설정: proxy_cache off
  역할: 캐싱 비활성화
  ────────────────────────────────────────
  설정: chunked_transfer_encoding off
  역할: SSE는 자체 스트리밍 프로토콜이므로 chunked 인코딩 불필요
  ────────────────────────────────────────
  설정: proxy_read_timeout 3600s
  역할: 읽기 타임아웃 1시간 (기본 60초면 연결 끊김)
  ────────────────────────────────────────
  설정: proxy_send_timeout 3600s
  역할: 쓰기 타임아웃 1시간
```

2. ec2 적용
```
docker exec <nginx-container> nginx -s reload
```