### PR TITLE
[FEATURE] service - JVM 힙 제한 설정 추가

### DIFF
--- a/service/docker-compose.yml
+++ b/service/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - .env
     environment:
       - TZ=Asia/Seoul
-      - JAVA_OPTS=-Xmx512m -Xms256m -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0
+      - "JAVA_OPTS=-Xmx256m -Xms128m -XX:+UseContainerSupport -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:${API_PORT}/actuator/health"]
       interval: 30s
@@ -54,7 +54,7 @@ services:
       - .env
     environment:
       - TZ=Asia/Seoul
-      - JAVA_OPTS=-Xmx512m -Xms256m -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0
+      - "JAVA_OPTS=-Xmx192m -Xms96m -XX:+UseContainerSupport -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:${REALTIME_PORT}/actuator/health"]
       interval: 30s


### PR DESCRIPTION
https://github.com/DeVine-2025/DeVine_BackEnd/pull/272


## close
스프링 실행 옵션 각 도커파일 -> 환경변수 처리 후 컴포즈에서 관리

- Xmx와 MaxRAMPercentage 동시 설정 시 Xmx가 우선하여 MaxRAMPercentage는 무의미 → 제거
- OOM 발생 시 JVM이 좀비 상태로 남아 healthcheck만 통과하는 문제 → ExitOnOutOfMemoryError로 즉시 종료 후 컨테이너 재시작
- OOM 원인 분석을 위한 힙 덤프를 호스트 볼륨(./logs/)에 보존

---

  API 서비스                                                                                                                                                                                               
                                                                                                                                                                                                           
  -Xmx256m -Xms128m -XX:+UseContainerSupport -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof                                                         
                                                                                                                                                                                                           
  Realtime 서비스                                                                                                                                                                                          
                                                                                                                                                                                                           
  -Xmx192m -Xms96m -XX:+UseContainerSupport -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof          


옵션 | 설명
-- | --
-Xmx | 최대 힙 크기. API 256m, Realtime 192m (기존 둘 다 512m)
-Xms | 초기 힙 크기. API 128m, Realtime 96m (기존 둘 다 256m)
-XX:+UseContainerSupport | 컨테이너 cgroup 메모리 제한을 인식. JDK 10+ 기본값이지만 명시적 선언
-XX:+ExitOnOutOfMemoryError | OOM 발생 시 JVM 즉시 종료 → Docker restart policy로 자동 재시작
-XX:+HeapDumpOnOutOfMemoryError | OOM 발생 시 힙 덤프 자동 생성 (사후 분석용)
-XX:HeapDumpPath=... | 힙 덤프 저장 경로. 호스트에서 logs/api/, logs/realtime/로 각각 분리됨

